### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#BalancedColumnLayout
+# BalancedColumnLayout
 
 A UICollectionViewLayout that displays your cells in a variable number of columns that fit to the bounds of the CollectionView.  Why? Cause every other layout that attempts to mimic the Pintrest waterfall layout (as this does) wants you to set the number of columns from the outside and I wanted my layout to figure that out for me so I didn't have to deal with it in the rotation logic.  Also I wanted a single layout setup for iPhone and iPad resolutions, and whatever comes next.
 
@@ -52,7 +52,7 @@ layout.cellWidth = 100;
 - (CGFloat)collectionView:(UICollectionView *)collectionView layout:(RBCollectionViewBalancedColumnLayout *)collectionViewLayout widthForCellsInSection:(NSInteger)section;
 ```
 
-####TODO
+#### TODO
 
 - [ ] Make more configurable
 - [x] Add ability to set unique cell widths per section


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
